### PR TITLE
Fixed folder structure crushing in bem-xjst

### DIFF
--- a/packages/gulp-bem-xjst/lib/gulp-bem-xjst.js
+++ b/packages/gulp-bem-xjst/lib/gulp-bem-xjst.js
@@ -125,13 +125,10 @@ module.exports.toHtml = function(templatesStream) {
                         throw new Error('Incorrect html result.');
                     }
 
-                    var name = path.basename(bemjsonFile.path).split('.')[0];
-                    var newFile = new File({
-                        path: name + (n-- || '') + '.html',
-                        contents: new Buffer(html)
-                    });
+                    bemjsonFile.path = bemjsonFile.path.split('.')[0] + (n-- || '') + '.html';
+                    bemjsonFile.contents = new Buffer(html);
 
-                    _this.push(newFile);
+                    _this.push(bemjsonFile);
                 });
 
                 callback();


### PR DESCRIPTION
When new file object adding by "this.push" instead of changing input file, it's relative path changing. So when i using glob pattern like this: `"\*\*/\*.bemjson.js"`, and have multiple folders with bemjson files, folder structure doesn't saves.

For example, i have gulp task like this:
```
gulp
	.src('layouts/**/*.bemjson.js')
	.pipe(toHtml(gulp
		.src(files.src.tmpls)
		.pipe(concat('blocks/*/*.bemhtml.js'))
		.pipe(bemhtml())
	))
	.pipe(gulp.dest('prod/layouts'));
```

And my folder structure:
```
layouts
 - pages
  - index.bemjson.js
 - parts
  - header.bemjson.js
```

In output, i will have structure like this:
```
layouts
 - index.html
 - header.html
```

I'm not pro in creating gulp plugins, but i tried to fix this problem just by changing path and contents of source ".bemjson" file, instead of creating new file. And it works! So now i have the same folder structure in input and output.

This is fixed output structure:
```
layouts
 - pages
  - index.html
 - parts
  - header.html
```